### PR TITLE
Docs: add a list of tested devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ESPHome for the Xiaomi Mi Air Purifier 3H (and similar devices using the same protocol)
+## ESPHome for various Xiaomi Air Purification Devices
 
 <p align="center"><img src="https://user-images.githubusercontent.com/36965186/219659691-6d8e733f-ae2f-4480-80ee-f5e90c9bd8f8.jpeg" width="400"></p>
 


### PR DESCRIPTION
Thanks for the ESPHome library! I had issues connecting my air purifier to Home Assistant via the Miio integration, this has saved my day!

Thought I'd expand the docs a bit by adding a list of supported devices. I have the Zhimi Air Purifier 3 (ma4).

![image](https://user-images.githubusercontent.com/12470297/229795735-d98bb37b-3b53-4eb1-8921-7c9c1e177619.png)
